### PR TITLE
fix rspec/matchers inclusion to be optional

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ begin
   RSpec::Core::RakeTask.new(:spec)
 rescue LoadError
   desc 'Run RSpec'
-  task :doc do
+  task :spec do
     abort 'Please install the rspec gem to run tests.'
   end
 end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -4,7 +4,12 @@ $:.unshift File.expand_path(File.join(File.dirname(__FILE__), '..', 'robots'))
 require 'rubygems'
 require 'bundler/setup'
 require 'logger'
-require 'rspec/matchers'
+
+begin
+  require 'rspec/matchers'
+rescue LoadError
+  # TODO: where is this rspec matchers used?
+end
 
 # Load the environment file based on Environment.  Default to development
 environment = ENV['ROBOT_ENVIRONMENT'] ||= 'development'


### PR DESCRIPTION
For some reason, we're including `rspec/matchers` in the master `boot.rb` file. This PR makes it optional (which happens in stage/prod when we do not deploy the rspec gems).
